### PR TITLE
Don't build trees for redundant alignments

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,7 @@
+# Snakemake parameters
+latency-wait: 20
+keep-going: True
+
 # input data
 hmm_dir:          'data/hmms-enabled'
 genome_batch_dir: 'data/genomes-enabled'

--- a/config/pbs/cluster.yaml
+++ b/config/pbs/cluster.yaml
@@ -1,11 +1,11 @@
 __default__:
   jobname: "{rule}_{wildcards}"
-  nodes: 24
-  ppn: 1
-  pmem: "128000mb"
+  nodes: 1
+  ncpus: 1
+  mem: "16gb"
   walltime: "24:00:00"
   account: "ACCOUNT"
-  queue: "cdb"
+  queue: "APC"
   email: "hpc@vort.org"
   mailon: "bea"
   jobout: "oe"

--- a/config/pbs/config.yaml
+++ b/config/pbs/config.yaml
@@ -1,6 +1,6 @@
 cluster-config: "config/pbs/cluster.yaml"
 cluster: "JOBNAME=`echo {cluster.jobname} | tr '=,:' '---'`; echo job name is $JOBNAME; qsub -N $JOBNAME -l select={cluster.nodes}:ncpus={cluster.ncpus}:mem={cluster.mem} -l walltime={cluster.walltime} -A {cluster.account} -q {cluster.queue} -M {cluster.email} -m {cluster.mailon} -j {cluster.jobout} -o {cluster.outdir} -V "
-jobs: 24 
+jobs: 1000 
 resources: [cpus=1, cores=1, mem_mb=6400]
 verbose: true
 notemp: true

--- a/config/pbs/config.yaml
+++ b/config/pbs/config.yaml
@@ -1,6 +1,6 @@
 cluster-config: "config/pbs/cluster.yaml"
-cluster: "JOBNAME=`echo {cluster.jobname} | tr '=,:' '---'`; echo job name is $JOBNAME; qsub -N $JOBNAME -l select={cluster.nodes}:ncpus={cluster.ppn}:mem={cluster.pmem} -l walltime={cluster.walltime} -A {cluster.account} -q {cluster.queue} -M {cluster.email} -m {cluster.mailon} -j {cluster.jobout} -o {cluster.outdir} -V "
-jobs: 4998
-resources: [cpus=24, mem_mb=6400]
+cluster: "JOBNAME=`echo {cluster.jobname} | tr '=,:' '---'`; echo job name is $JOBNAME; qsub -N $JOBNAME -l select={cluster.nodes}:ncpus={cluster.ncpus}:mem={cluster.mem} -l walltime={cluster.walltime} -A {cluster.account} -q {cluster.queue} -M {cluster.email} -m {cluster.mailon} -j {cluster.jobout} -o {cluster.outdir} -V "
+jobs: 24 
+resources: [cpus=1, cores=1, mem_mb=6400]
 verbose: true
 notemp: true

--- a/config/pbs/submit1.sh
+++ b/config/pbs/submit1.sh
@@ -13,7 +13,7 @@
 ####    an the amount of time a job requires.  May include processor
 ####    type, too.
 
-#PBS -l nodes=1:ppn=1,pmem=10000mb
+#PBS -l nodes=1:ncpus=1,pmem=18gb
 #PBS -l walltime=24:00:00
 
 ####  Flux account and queue specification here
@@ -21,8 +21,8 @@
 ####    special hardware, like large memory nodes or GPUs or,
 ####    or if you use software that is restricted to campus use.
 
-#PBS -A ACCOUNT
-#PBS -q cdb
+####PBS -A ACCOUNT
+#PBS -q APC
 
 #### #### ####  These are the least frequently changing options
 
@@ -33,8 +33,8 @@
 
 ####  Join output and error; pass environment to job
 
-#PBS -j oe
-#PBS -o logs/pds/
+#PBS -e logs/pbs/
+#PBS -o logs/pbs/
 #PBS -V
 
 # Add a note here to say what software modules should be loaded.

--- a/config/pbs/submit2.sh
+++ b/config/pbs/submit2.sh
@@ -13,16 +13,16 @@
 ####    an the amount of time a job requires.  May include processor
 ####    type, too.
 
-#PBS -l nodes=1:ppn=1,pmem=10000mb
-#PBS -l walltime=8:00:00
+#PBS -l select=1:ncpus=1:mem=18gb
+#PBS -l walltime=96:00:00
 
 ####  Flux account and queue specification here
 ####    These will change if you work on multiple projects, or need
 ####    special hardware, like large memory nodes or GPUs or,
 ####    or if you use software that is restricted to campus use.
 
-#PBS -A ACCOUNT
-#PBS -q cdb
+#### PBS -A ACCOUNT
+#PBS -q APC
 
 #### #### ####  These are the least frequently changing options
 
@@ -33,8 +33,8 @@
 
 ####  Join output and error; pass environment to job
 
-#PBS -j oe
-#PBS -o logs/pds/
+#PBS -e logs/pbs/
+#PBS -o logs/pbs/
 #PBS -V
 
 # Add a note here to say what software modules should be loaded.
@@ -75,20 +75,11 @@ mkdir -p logs
 mkdir -p logs/pbs
 
 # Initiating snakemake and running workflow in cluster mode
-snakemake                           \
-    --snakefile workflow/Snakefile2 \
-#   --jobs 8                        \
-    --profile config/pbs            \
-    --latency-wait 5                \
-    --group-components              \
-        phylogenetics=16            \
-        phylogenomics=1             \
-
-snakemake                           \
-    --snakefile workflow/Snakefile2 \
-    --latency-wait 5                \
-    --profile config/pbs            \
-    --jobs 16
+snakemake                                \
+    --snakefile workflow/Snakefile2      \
+    --profile config/pbs                 \
+    --group-components phylogenetics=512 \
+    --rerun-incomplete                   \
 
 # Printing out job summary
 qstat -f $PBS_JOBID

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -70,7 +70,7 @@ SEED = 31173
 
 rule all :
   input :
-    'cluster_data/clusters.tsv'
+    'cluster_data/redundancy.tsv'
 
 rule clean :
   shell :
@@ -300,7 +300,7 @@ rule build_clusters :
     genes         = expand( 'genes/{batch}.fna', batch=GENOMES ),
     ani_clusters  = expand( 'ani_clusters/ani_clusters_{ani_cutoff}.txt', ani_cutoff=ANI_THRESHOLDS )
   output :
-    cluster_table = 'cluster_data/clusters.tsv',
+    redundancy    = 'cluster_data/redundancy.tsv',
     clusters      = directory( 'clusters' ),
   params :
     ANIs = ANI_THRESHOLDS,
@@ -310,92 +310,87 @@ rule build_clusters :
   benchmark :
     'benchmarks/cluster_filtering/cluster_filtering.tsv'
   run :
+
     def intersect( hmms, genomes, threshold ) :
-      C = defaultdict( set )
-      for hmm,genome in zip( hmms, genomes ) :
-        C[hmm].add(genome)
-      return sum( [ len( C[a] & C[b] ) > threshold
-                    for a,b in combinations( C.keys(), 2 ) ] )
-    
+        C = defaultdict( set )
+        for hmm,genome in zip( hmms, genomes ) :
+            C[hmm].add(genome)
+        return sum( [ len( C[a] & C[b] ) > threshold
+                      for a,b in combinations( C.keys(), 2 ) ] )
+
     with open( log[0], 'w' ) as LOG :
-      LOG.write( 'indexing sequences...\n' )
+      
+      clusterpath = 'clusters'
 
-      sequences = { Path(faa).stem : pysam.FastaFile( faa ) 
-                    for faa in input.prealignments
-                    if os.path.getsize( faa ) > 0 } 
-      
-      LOG.write( 'loading sequences...\n' )
-      
-      hmm2gene = polars.DataFrame( [ { 'hmm'     : hmm,
-                                       'gene'    : seq_id.rsplit('_',1)[0],
-                                       'genome'  : seq_id.rsplit('_',4)[0],
-                                       'prank'   : int(seq_id.rsplit('_p',1)[1]),
-                                       'paralog' : seq_id }
-                                     for hmm    in sequences.keys() 
-                                     for seq_id in sequences[hmm].references ] )
-      
-      LOG.write( 'proteins loaded   : {n}\n'.format( n=str( len(hmm2gene) ) ) )
-      
-      genes = dict( ChainMap( *[ { name : fasta[name] for name in fasta.references }
-                                 for fasta in [ pysam.FastaFile( fna )
-                                                for fna in input.genes
-                                                if os.path.getsize( fna ) > 0 ] ] ) )
-
-      LOG.write( 'genes loaded : {n}\n'.format( n=str( len(genes) ) ) )
-      
-      LOG.write( 'loading genome ANI cluster tables...\n' )
-      
-      data = []
-      for ani,clusterfile in zip( params.ANIs, input.ani_clusters ) :
-        for cid,names in [ line.split() for line in open( clusterfile ) ] :
-          for genome in names.split(',') :
-            data.append( { 'ani'    : ani,
-                           'cid'    : int(cid),
-                           'genome' : genome } )
-      
-      genome_ani = polars.DataFrame( data )
-      
       LOG.write( 'creating directory for gene data for ANI clusters....\n' )
 
-      if not os.path.exists( 'clusters' ) : os.mkdir( 'clusters' )
-      
+      if not os.path.exists( clusterpath ) : os.mkdir( clusterpath )
+
+      genesets = {}
+
       for ANI in params.ANIs :
-        LOG.write( 'finding gene families at ANI={ani}...\n'.format( ani=str(ANI) ) )
-
-        df = hmm2gene.join( genome_ani.filter( polars.col('ani') == ANI ), on='genome' )
-
-        clusters = df.group_by('cid').agg( ['hmm','genome'] ).map_rows(
-                         lambda x : ( x[0],
-                                      intersect( x[1], 
-                                                 x[2],
-                                                 params.MCL ) ) ).filter( polars.col('column_1') > 0 )['column_0'].to_list()
-
-        LOG.write( '   found {n} potentially informative clusters...\n'.format( n=str( len(clusters) ) ) )
-
-        cluster_table = df.filter( polars.col('cid').is_in( clusters ) )
-        
-        LOG.write( '   creating directory for gene data for ANI={n}...\n'.format( n=str(ANI) ) )
-        
-        anipath = os.path.join( 'clusters', str(ANI) )
-        if not os.path.exists( anipath ) : os.mkdir( anipath )
-
-        HMMS,GENES = 0,0
-        for cid in cluster_table['cid'].unique().to_list() :
           
-          clusterpath = os.path.join( anipath, str( cid ) )
-          if not os.path.exists( clusterpath ) : os.mkdir( clusterpath )
-          genepath = os.path.join( clusterpath, 'genes' )
-          if not os.path.exists( genepath ) : os.mkdir( genepath )
+          genesets[ANI] = {}
           
-          for hmm in cluster_table.filter( polars.col('cid') == cid )['hmm'].unique().to_list() :
-            HMMS = HMMS + 1
-            records = cluster_table.filter( ( polars.col('cid') == cid ) 
-                                          & ( polars.col('hmm') == hmm ) )['gene'].to_list()
-            if not records : continue
-            with open( os.path.join( genepath, hmm + '.fna'), 'w' ) as f :
-              for gene in records :
-                GENES = GENES + 1
-                f.write( '>{seq_id}\n{seq}\n'.format( seq_id = gene,
-                                                      seq    = genes[gene] ) )
+          LOG.write( 'finding gene families at ANI={ani}...\n'.format( ani=str(ANI) ) )
           
-        LOG.write( '    wrote {G} sequences for {H} genes.\n'.format( G=str(GENES), H=str(HMMS) ) )
+          df = hmm2gene.join( genome_ani.filter( polars.col('ani') == ANI ), on='genome' )
+          
+          clusters = df.group_by('cid').agg( ['hmm','genome'] ).map_rows(
+                          lambda x : ( x[0],
+                                        intersect( x[1], 
+                                                  x[2],
+                                                  params.MCL ) ) ).filter( polars.col('column_1') > 0 )['column_0'].to_list()
+          
+          LOG.write( '   found {n} potentially informative clusters...\n'.format( n=str( len(clusters) ) ) )
+          
+          cluster_table = df.filter( polars.col('cid').is_in( clusters ) )
+          
+          LOG.write( '   creating directory for gene data for ANI={n}...\n'.format( n=str(ANI) ) )
+          
+          anipath = os.path.join( clusterpath, str(ANI) )
+          if not os.path.exists( anipath ) : os.mkdir( anipath )
+          
+          HMMS,GENES = 0,0
+          for cid in cluster_table['cid'].unique().to_list() :
+
+              genesets[ANI][cid] = {}
+              
+              cidpath = os.path.join( anipath, str( cid ) )
+              if not os.path.exists( cidpath ) : os.mkdir( cidpath )
+              genepath = os.path.join( cidpath, 'genes' )
+              if not os.path.exists( genepath ) : os.mkdir( genepath )
+            
+              for hmm in cluster_table.filter( polars.col('cid') == cid )['hmm'].unique().to_list() :
+                  HMMS = HMMS + 1
+                  records = cluster_table.filter( ( polars.col('cid') == cid ) 
+                                            & ( polars.col('hmm') == hmm ) )['gene'].to_list()
+                  if len(records) < MCL : continue
+                  genesets[ANI][cid][hmm] = frozenset( records )
+                  with open( os.path.join( genepath, hmm + '.fna'), 'w' ) as f :
+                      for gene in records :
+                          GENES = GENES + 1
+                          f.write( '>{seq_id}\n{seq}\n'.format( seq_id = gene,
+                                                                seq    = genes[gene] ) )
+            
+          LOG.write( '   wrote {G} sequences for {H} genes.\n'.format( G=str(GENES), H=str(HMMS) ) )
+
+      hmmtable = polars.DataFrame( 
+          [ { 'fna' : '{ani}/{cid}/genes/{hmm}.fna'.format( ani=ani,
+                                                            cid=cid,
+                                                            hmm=hmm ),
+              'id'  : ':'.join( sorted( genesets[ani][cid][hmm] ) ) }
+            for ani in genesets
+            for cid in genesets[ani]
+            for hmm in genesets[ani][cid] ] )
+
+      LOG.write( 'total alignments  : {n}\n'.format( n=len(alltable) ) )
+      LOG.write( 'unique alignments : {n}\n'.format( n=len( hmmtable['id'].unique() ) ) )
+      LOG.write( 'percent unique    : {n:.1f}%\n'.format( n=(len(allhmms)/len( hmmtable['id'].unique() )*100 ) ) )
+
+      with open( output.redunancy, 'w' ) as f :
+          f.write( '\n'.join( [ '\t'.join( row[1] )
+                                for row
+                                in hmmtable.group_by( 'id' ).agg( 'fna' ).rows() ] ) )
+      
+      LOG.write( 'redundancy table written.')

--- a/workflow/Snakefile2
+++ b/workflow/Snakefile2
@@ -51,6 +51,9 @@ ANI_THRESHOLDS = linspace( config['ani_thresholds_min'],
                            config['ani_thresholds_max'],
                            config['ani_thresholds_n'] )
 
+NON_REDUNDANT_TREES = [ os.path.join( 'clusters',
+                                      line.split()[0].replace( 'genes', 'trees/by_gene' ).replace('.fna','.nwk') ) 
+                        for line in open( 'cluster_data/redundancy.tsv' ) ]
 
 def cluster_trees( wildcards ) :
   
@@ -73,7 +76,7 @@ def cluster_trees( wildcards ) :
 
 rule all :
   input :
-    cluster_trees
+    NON_REDUNDANT_TREES
 
 rule mafft :
   group : 'phylogenetics'

--- a/workflow/Snakefile2
+++ b/workflow/Snakefile2
@@ -59,14 +59,15 @@ NON_REDUNDANT_TREES = [ os.path.join( 'clusters',
 # hilariously broken
 
 treepaths_required = {}
-  for line in open( 'cluster_data/redundancy.tsv' ) :
-    ani, cid, folder, fasta = Path( line.split()[0] ).parts
-    treepaths_required.append( os.path.join( 'clusters', 
-                                             ani,
-                                             cid,
-                                             'trees',
-                                             'by_gene',
-                                             Path(fasta).stem + '.nwk' ) )
+for line in open( 'cluster_data/redundancy.tsv' ) :
+  ani, cid, folder, fasta = Path( line.split()[0] ).parts
+  treepaths_required.append( os.path.join( 'clusters', 
+                                           ani,
+                                           cid,
+                                           'trees',
+                                           'by_gene',
+                                            Path(fasta).stem + '.nwk' ) )
+
 treepaths = {}
 for ani in os.listdir( 'clusters' ) :
   for cid in os.listdir( os.path.join( 'clusters', ani ) ) :

--- a/workflow/Snakefile2
+++ b/workflow/Snakefile2
@@ -58,17 +58,17 @@ NON_REDUNDANT_TREES = [ os.path.join( 'clusters',
 # doing this the dumb way, because glob_wildcards is
 # hilariously broken
 
-treepaths_required = {}
+treepaths_required = set()
 for line in open( 'cluster_data/redundancy.tsv' ) :
   ani, cid, folder, fasta = Path( line.split()[0] ).parts
-  treepaths_required.append( os.path.join( 'clusters', 
-                                           ani,
-                                           cid,
-                                           'trees',
-                                           'by_gene',
-                                            Path(fasta).stem + '.nwk' ) )
+  treepaths_required.add( os.path.join( 'clusters', 
+                                        ani,
+                                        cid,
+                                       'trees',
+                                       'by_gene',
+                                        Path(fasta).stem + '.nwk' ) )
 
-treepaths = {}
+treepaths = set()
 for ani in os.listdir( 'clusters' ) :
   for cid in os.listdir( os.path.join( 'clusters', ani ) ) :
     if not 'trees' in os.listdir( os.path.join( 'clusters', ani, cid ) ) : continue

--- a/workflow/Snakefile2
+++ b/workflow/Snakefile2
@@ -55,28 +55,33 @@ NON_REDUNDANT_TREES = [ os.path.join( 'clusters',
                                       line.split()[0].replace( 'genes', 'trees/by_gene' ).replace('.fna','.nwk') ) 
                         for line in open( 'cluster_data/redundancy.tsv' ) ]
 
-def cluster_trees( wildcards ) :
-  
-  WC = glob_wildcards( os.path.join( 'clusters',
-                                     '{ani}',
-                                     '{cid}',
-                                     'genes',
-                                     '{hmm}.fna' ) )
-  
-  return expand( os.path.join( 'clusters',
-                               '{ani}',
-                               '{cid}',
-                               'trees',
-                               'by_gene',
-                               '{hmm}.nwk' ),
-                 zip,
-                 ani=WC.ani,
-                 cid=WC.cid,
-                 hmm=WC.hmm )
+# doing this the dumb way, because glob_wildcards is
+# hilariously broken
+
+treepaths_required = {}
+  for line in open( 'cluster_data/redundancy.tsv' ) :
+    ani, cid, folder, fasta = Path( line.split()[0] ).parts
+    treepaths_required.append( os.path.join( 'clusters', 
+                                             ani,
+                                             cid,
+                                             'trees',
+                                             'by_gene',
+                                             Path(fasta).stem + '.nwk' ) )
+treepaths = {}
+for ani in os.listdir( 'clusters' ) :
+  for cid in os.listdir( os.path.join( 'clusters', ani ) ) :
+    if not 'trees' in os.listdir( os.path.join( 'clusters', ani, cid ) ) : continue
+    for tree in os.listdir( os.path.join( 'clusters', ani, cid, 'trees', 'by_gene' ) ) :
+      treepaths.add( os.path.join( 'clusters',
+                                   ani,
+                                   cid,
+                                   'trees',
+                                   'by_gene',
+                                   tree ) )
 
 rule all :
   input :
-    NON_REDUNDANT_TREES
+    treepaths ^ treepaths_required
 
 rule mafft :
   group : 'phylogenetics'

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -51,17 +51,6 @@ ANI_THRESHOLDS = linspace( config['ani_thresholds_min'],
                            config['ani_thresholds_max'],
                            config['ani_thresholds_n'] )
 
-def fastapath_to_treepath( p ) :
-  ani, cid, folder, fasta = Path(p).parts
-  return( os.path.join( 'clusters', ani, cid, 'trees', 'by_gene', Path(p).stem + '.nwk' ) )
-
-REDUNDANT_TREE_MAP = {}
-
-for line in open( 'cluster_data/redundancy.tsv' ) :
-  fastas = line.split()
-  for fasta in fastas :
-    REDUNDANT_TREE_MAP[ fastapath_to_treepath( fasta ) ] = fastapath_to_treepath( fastas[0] )
-
 def cluster_trees( wildcards ) :
   
   WC = glob_wildcards( os.path.join( 'clusters',
@@ -82,8 +71,35 @@ def cluster_trees( wildcards ) :
                  hmm=WC.hmm )
 
 rule all :
+  output :
+    'clusters/{ani}/{cid}/data.tsv'
+
+rule symlinks :
+  group : 'phylogenomics'
   input :
-    REDUNDANT_TREE_MAP.keys()
+    rtm = 'cluster_data/redundancy.tsv' 
+  output :
+    'clusters/{ani}/{cid}/trees/by_gene/{hmm}.nwk'
+  run :
+    def fastapath_to_treepath( p ) :
+      ani, cid, folder, fasta = Path(p).parts
+      return( os.path.join( 'clusters',
+                            ani,
+                            cid,
+                            'trees',
+                            'by_gene',
+                            Path(p).stem + '.nwk' ) )
+    
+    rtm = {}
+    
+    for line in open() :
+      fastas = line.split()
+      for fasta in fastas :
+        candidate = fastapath_to_treepath( fastas[0] )
+        base      = fastapath_to_treepath( fasta )
+        if candidate == base : continue
+        if not os.path.exists( candidate ) :
+          os.path.symlink( base, candidate )
 
 rule clusterdata :
   group : 'phylogenomics'

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -170,7 +170,7 @@ rule clusterdata :
         r,pr = pearsonr(   hmm1_distances, hmm2_distances )
         t,pt = kendalltau( hmm1_distances, hmm2_distances )
         
-        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) )
+        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) \
                 / len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
         
         bp_compat = bipartition_compatibility_ratio( T1, T2, links )

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -170,7 +170,7 @@ rule clusterdata :
         r,pr = pearsonr(   hmm1_distances, hmm2_distances )
         t,pt = kendalltau( hmm1_distances, hmm2_distances )
         
-        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) \
+        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) /
                   len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
         
         bp_compat = bipartition_compatibility_ratio( T1, T2, links )

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -69,7 +69,7 @@ for line in open( 'cluster_data/redundancy.tsv' ) :
 
 RTM = polars.DataFrame( RTM )
 
-def cluster_paths( wildcards ) :
+def cluster_data( wildcards ) :
   
   WC = glob_wildcards( os.path.join( 'clusters',
                                      '{ani}',
@@ -77,14 +77,15 @@ def cluster_paths( wildcards ) :
   
   return expand( os.path.join( 'clusters',
                                '{ani}',
-                               '{cid}' ),
+                               '{cid}',
+                                'data.tsv' ),
                  zip,
                  ani=WC.ani,
                  cid=WC.cid )
 
 rule all :
-  input :
-    cluster_paths
+  output :
+    cluster_data
 
 rule clusterdata :
   group : 'phylogenomics'

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -116,7 +116,7 @@ rule clusterdata :
       for hmm1, hmm2 in combinations( treepaths.keys(), 2 ) :
         
         treefile1 = treepaths[hmm1]
-        treefile2 = treepaths[hmm2
+        treefile2 = treepaths[hmm2]
         
         # if either treefile is an empty sentilel file, skip the calculations
         if os.stat( treefile1 ).st_size == 0 : continue

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -108,7 +108,7 @@ rule clusterdata :
       treepaths = {}
       for ani,cid,hmm,tree for RTM.filter( ani=params.ani,
                                            cid=params.cid ).iter_rows() :
-        LOG.write( '  {hmm} -> {tree}\n'.format( hmm=hmm, tree=tree ) )
+        LOG.write( '    {hmm} -> {tree}\n'.format( hmm=hmm, tree=tree ) )
         treepaths[hmm] = tree
 
       data = []
@@ -170,8 +170,8 @@ rule clusterdata :
         r,pr = pearsonr(   hmm1_distances, hmm2_distances )
         t,pt = kendalltau( hmm1_distances, hmm2_distances )
         
-        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) /
-                  len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
+        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) \
+                / len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
         
         bp_compat = bipartition_compatibility_ratio( T1, T2, links )
         

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -187,4 +187,6 @@ rule clusterdata :
         LOG.write( 'writing records for {n} correlations...\n'.format( n=len( data ) ) )
         polars.DataFrame( data ).write_csv( file=output[0], separator='\t' )
       else :
+        with open( output[0], 'w' ) as f :
+          pass
         LOG.write( 'no gene pairs exceed minimum link threshold, aborting.\n' )

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -70,7 +70,7 @@ for line in open( 'cluster_data/redundancy.tsv' ) :
 RTM = polars.DataFrame( RTM )
 
 rule all :
-  output :
+  input :
     [ os.path.join( 'clusters', ani, cid, 'data.tsv' )
       for ani in os.listdir( 'clusters' )
       for cid in os.listdir( os.path.join( 'clusters', ani ) ) ]

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -53,7 +53,7 @@ ANI_THRESHOLDS = linspace( config['ani_thresholds_min'],
 
 def fastapath_to_treepath( p ) :
   ani, cid, folder, fasta = Path(p).parts
-  return( os.path.join( ani, cid, 'trees', 'by_gene', Path(p).stem + '.nwk' ) )
+  return( os.path.join( 'clusters', ani, cid, 'trees', 'by_gene', Path(p).stem + '.nwk' ) )
 
 REDUNDANT_TREE_MAP = {}
 

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -57,7 +57,7 @@ def fastapath_to_treepath( p ) :
 
 REDUNDANT_TREE_MAP = {}
 
-for line in open( '/tmp/redundancy.tsv' ) :
+for line in open( 'cluster_data/redundancy.tsv' ) :
   fastas = line.split()
   for fasta in fastas :
     REDUNDANT_TREE_MAP[ fastapath_to_treepath( fasta ) ] = fastapath_to_treepath( fastas[0] )

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -106,8 +106,8 @@ rule clusterdata :
       LOG.write( 'cluster ID : {cid}\n'.format( cid=params.cid ) )
       
       treepaths = {}
-      for ani,cid,hmm,tree for RTM.filter( ani=params.ani,
-                                           cid=params.cid ).iter_rows() :
+      for ani,cid,hmm,tree in RTM.filter( ani=params.ani,
+                                          cid=params.cid ).iter_rows() :
         LOG.write( '    {hmm} -> {tree}\n'.format( hmm=hmm, tree=tree ) )
         treepaths[hmm] = tree
 

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -115,8 +115,8 @@ rule clusterdata :
         T2 = SuchTree( treefile2 )
         links = find_links( list( T1.leafs.keys() ), list( T2.leafs.keys() ) )
         
-        LOG.write( '    {g1} : {n} leafs\n'.format( g1=hmm1_name, n=T1.n_leafs ) )
-        LOG.write( '    {g2} : {n} leafs\n'.format( g2=hmm2_name, n=T2.n_leafs ) )
+        LOG.write( '    {g1} : {n} leafs\n'.format( g1=hmm1, n=T1.n_leafs ) )
+        LOG.write( '    {g2} : {n} leafs\n'.format( g2=hmm2, n=T2.n_leafs ) )
         LOG.write( '    links : {n}\n'.format( n=len(links) ) )
         
         # some clusters may have lost enough members during trimming and filtering

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -170,8 +170,7 @@ rule clusterdata :
         r,pr = pearsonr(   hmm1_distances, hmm2_distances )
         t,pt = kendalltau( hmm1_distances, hmm2_distances )
         
-        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) \
-                / len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
+        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) / len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
         
         bp_compat = bipartition_compatibility_ratio( T1, T2, links )
         

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -77,8 +77,6 @@ rule all :
 
 rule clusterdata :
   group : 'phylogenomics'
-  input :
-    cluster = 'clusters/{ani}/{cid}'
   output :
     table = 'clusters/{ani}/{cid}/data.tsv'
   params :

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -157,8 +157,7 @@ rule clusterdata :
         r,pr = pearsonr(   hmm1_distances, hmm2_distances )
         t,pt = kendalltau( hmm1_distances, hmm2_distances )
         
-        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) \
-                / len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
+        jaccard = len(links) / ( T1.n_leafs + T2.n_leafs )
         
         bp_compat = bipartition_compatibility_ratio( T1, T2, links )
         

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -1,0 +1,200 @@
+include : 'Importer'
+
+# load configuration
+configfile : 'config/config.yaml'
+
+from utils import parse_hmmsearch
+from utils import bipartition_compatibility, bipartition_compatibility_ratio
+from utils import find_links
+
+import os, pandas, polars, dendropy
+from pathlib import Path
+from copy import deepcopy
+from hmm_profile import reader, writer
+from cdhit_reader import read_cdhit
+from Bio.SeqIO import parse
+from Bio import AlignIO, SearchIO
+from Bio.Align import MultipleSeqAlignment
+from numpy import linspace, zeros, unique
+from collections import defaultdict
+from itertools import combinations, product
+from scipy.cluster.hierarchy import single, fcluster
+from scipy.spatial.distance import squareform
+from scipy.stats import kendalltau, pearsonr, skew, kurtosis
+from statistics import stdev
+from SuchTree import SuchTree, SuchLinkedTrees
+
+from utils import clustalo_memory, trimal_memory, fasttree_memory
+
+HMMS_DIR    = config['hmm_dir']
+GENOMES_DIR = config['genome_batch_dir']
+
+# minimum number of links per cluster for tree correlation
+MIN_CLUSTER_LINKS = config['min_cluster_links']
+
+# degenerate tree threshold : exclude pairwise tree-to-tree
+# comparisons where the ratio of non-unique leaf-to-leaf
+# distances exceeds this threshold
+DEGEN_THRESHOLD = config['degeneracy_threshold']
+
+# e-value threshold for HMM search
+EVALUE = config['evalue']
+
+# post-trimming aligned fraction threshold
+AFT = config['aligned_fraction_threshold']
+
+# threads to use when invoking multithreaded applications
+THREADS = config['threads']
+
+# cutoff thresholds for genome ANI clustering
+ANI_THRESHOLDS = linspace( config['ani_thresholds_min'],
+                           config['ani_thresholds_max'],
+                           config['ani_thresholds_n'] )
+
+def fastapath_to_treepath( p ) :
+  ani, cid, folder, fasta = Path(p).parts
+  return( os.path.join( ani, cid, 'trees', 'by_gene', Path(p).stem + '.nwk' ) )
+
+REDUNDANT_TREE_MAP = {}
+
+for line in open( '/tmp/redundancy.tsv' ) :
+  fastas = line.split()
+  for fasta in fastas :
+    REDUNDANT_TREE_MAP[ fastapath_to_treepath( fasta ) ] = fastapath_to_treepath( fastas[0] )
+
+def cluster_trees( wildcards ) :
+  
+  WC = glob_wildcards( os.path.join( 'clusters',
+                                     '{ani}',
+                                     '{cid}',
+                                     'genes',
+                                     '{hmm}.fna' ) )
+  
+  return expand( os.path.join( 'clusters',
+                               '{ani}',
+                               '{cid}',
+                               'trees',
+                               'by_gene',
+                               '{hmm}.nwk' ),
+                 zip,
+                 ani=WC.ani,
+                 cid=WC.cid,
+                 hmm=WC.hmm )
+
+rule all :
+  input :
+    REDUNDANT_TREE_MAP.keys()
+
+rule clusterdata :
+  group : 'phylogenomics'
+  input :
+    trees = 'clusters/{ani}/{cid}/trees/by_gene/{hmm}.nwk'
+  output :
+    table = 'clusters/{ani}/{cid}/data.tsv'
+  params :
+    ani   = '{ani}',
+    cid   = '{cid}',
+  log :
+    'logs/clusterdata/{ani}_{cid}.log'
+  benchmark :
+    'benchmarks/clusterdata/{ani}_{cid}.tsv'
+  run :
+    with open( log[0], 'w' ) as LOG :
+       
+      LOG.write( 'ANI        : {ani}\n'.format( ani=params.ani ) )
+      LOG.write( 'cluster ID : {cid}\n'.format( cid=params.cid ) )
+      
+      LOG.write( 'input trees :\n' )
+      for treefile in input.trees :
+        LOG.write( '    {f}\n'.format( f=treefile ) )
+      
+      data = []
+      
+      for treepath1, treepath2 in combinations( input.trees, 2 ) :
+        
+        # if a tree is redundant, use the base tree
+        treefile1 = REDUNDANT_TREE_MAP[ treepath1 ]
+        treefile2 = REDUNDANT_TREE_MAP[ treefile2 ]
+        
+        # if either treefile is an empty sentilel file, skip the calculations
+        if os.stat( treefile1 ).st_size == 0 : continue
+        if os.stat( treefile2 ).st_size == 0 : continue
+        
+        hmm1_name = Path( treefile1 ).stem.rsplit( '.', 1 )[0]
+        hmm2_name = Path( treefile2 ).stem.rsplit( '.', 1 )[0]
+        
+        LOG.write( 'loading {g1} and {g2}...\n'.format( g1=hmm1_name, g2=hmm2_name ) )
+        
+        T1 = SuchTree( treefile1 )
+        T2 = SuchTree( treefile2 )
+        links = find_links( list( T1.leafs.keys() ), list( T2.leafs.keys() ) )
+        
+        LOG.write( '    {g1} : {n} leafs\n'.format( g1=hmm1_name, n=T1.n_leafs ) )
+        LOG.write( '    {g2} : {n} leafs\n'.format( g2=hmm2_name, n=T2.n_leafs ) )
+        LOG.write( '    links : {n}\n'.format( n=len(links) ) )
+        
+        # some clusters may have lost enough members during trimming and filtering
+        # that they no longer meet the link threshold
+        if len(links) < MIN_CLUSTER_LINKS :
+          LOG.write( 'gene pair is below minimum link threshold; aborting.\n' )
+          continue
+        
+        hmm1_pairs = []
+        hmm2_pairs = []
+        
+        for (t1a,t2a),(t1b,t2b) in combinations( links, 2 ) :
+          hmm1_pairs.append( ( t1a, t1b ) )
+          hmm2_pairs.append( ( t2a, t2b ) )
+        
+        hmm1_distances = T1.distances_by_name( hmm1_pairs )
+        hmm2_distances = T2.distances_by_name( hmm2_pairs )
+        
+        LOG.write( '    computed {n} distances.\n'.format( n=str( len( hmm1_distances ) ) ) )
+        
+        # skip degenerate trees
+        if len( unique( hmm1_distances ) ) / len( hmm1_distances ) < DEGEN_THRESHOLD :
+          LOG.write( '    {g1} is degenerate, skipping.\n'.format( g1=hmm1_name ) )
+          continue
+        if len( unique( hmm2_distances ) ) / len( hmm2_distances ) < DEGEN_THRESHOLD :
+          LOG.write( '    {g2} is degenerate, skipping.\n'.format( g2=hmm2_name ) )
+          continue
+        
+        hmm1_skew = skew( hmm1_distances )
+        hmm2_skew = skew( hmm2_distances )
+        
+        hmm1_kurtosis = kurtosis( hmm1_distances )
+        hmm2_kurtosis = kurtosis( hmm2_distances )
+         
+        hmm1_stdev = stdev( hmm1_distances )
+        hmm2_stdev = stdev( hmm2_distances )
+         
+        r,pr = pearsonr(   hmm1_distances, hmm2_distances )
+        t,pt = kendalltau( hmm1_distances, hmm2_distances )
+        
+        bp_compat = bipartition_compatibility_ratio( T1, T2, links )
+        
+        data.append(  { 'hmm1'          : hmm1_name,
+                        'hmm2'          : hmm2_name,
+                        'hmm1_leafs'    : T1.n_leafs,
+                        'hmm2_leafs'    : T2.n_leafs,
+                        'links'         : len(links),
+                        'hmm1_skew'     : hmm1_skew,
+                        'hmm2_skew'     : hmm2_skew,
+                        'hmm1_kurtosis' : hmm1_kurtosis,
+                        'hmm2_kurtosis' : hmm2_kurtosis,
+                        'hmm1_stdev'    : hmm1_stdev,
+                        'hmm2_stdev'    : hmm2_stdev,
+                        'bp_ratio'      : bp_compat['ratio'],
+                        'bp_jaccard'    : bp_compat['jaccard'],
+                        'r'             : r,
+                        'pr'            : pr,
+                        'tau'           : t,
+                        'p_tau'         : pt,
+                        'cluster'       : int( params.cid ),
+                        'ANI'           : float( params.ani) } )
+      
+      if data :
+        LOG.write( 'writing records for {n} correlations...\n'.format( n=len( data ) ) )
+        polars.DataFrame( data ).write_csv( file=output[0], separator='\t' )
+      else :
+        LOG.write( 'no gene pairs exceed minimum link threshold, aborting.\n' )

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -51,61 +51,45 @@ ANI_THRESHOLDS = linspace( config['ani_thresholds_min'],
                            config['ani_thresholds_max'],
                            config['ani_thresholds_n'] )
 
-def cluster_trees( wildcards ) :
+RTM = []
+
+for line in open( 'cluster_data/redundancy.tsv' ) :
+  fastas = line.split()
+  ani, cid, folder, basefasta = Path( fastas[0] ).parts
+  basetree = os.path.join( 'clusters',
+                           ani,
+                           cid,
+                           'trees',
+                           'by_gene',
+                           Path(basefasta).stem + '.nwk' ) )
+  for fasta in fastas :
+    ani, cid, folder, candidatefasta = Path( fasta ).parts
+    hmm = Path(fasta).stem
+    RTM.append( { 'ani' : ani, 'cid' : cid, 'hmm' : hmm, 'tree' : basetree } )
+
+RTM = polars.DataFrame( RTM )
+
+def cluster_paths( wildcards ) :
   
   WC = glob_wildcards( os.path.join( 'clusters',
                                      '{ani}',
-                                     '{cid}',
-                                     'trees',
-                                     'by_gene',
-                                     '{hmm}.nwk' ) )
+                                     '{cid}' ) )
   
   return expand( os.path.join( 'clusters',
                                '{ani}',
-                               '{cid}',
-                               'trees',
-                               'by_gene',
-                               '{hmm}.nwk' ),
+                               '{cid}' ),
                  zip,
                  ani=WC.ani,
-                 cid=WC.cid,
-                 hmm=WC.hmm )
+                 cid=WC.cid )
 
 rule all :
   input :
-    cluster_trees
-
-rule symlinks :
-  group : 'phylogenomics'
-  input :
-    rtm = 'cluster_data/redundancy.tsv' 
-  output :
-    'clusters/{ani}/{cid}/trees/by_gene/{hmm}.nwk'
-  run :
-    def fastapath_to_treepath( p ) :
-      ani, cid, folder, fasta = Path(p).parts
-      return( os.path.join( 'clusters',
-                            ani,
-                            cid,
-                            'trees',
-                            'by_gene',
-                            Path(p).stem + '.nwk' ) )
-    
-    rtm = {}
-    
-    for line in open() :
-      fastas = line.split()
-      for fasta in fastas :
-        candidate = fastapath_to_treepath( fastas[0] )
-        base      = fastapath_to_treepath( fasta )
-        if candidate == base : continue
-        if not os.path.exists( candidate ) :
-          os.path.symlink( base, candidate )
+    cluster_paths
 
 rule clusterdata :
   group : 'phylogenomics'
   input :
-    trees = 'clusters/{ani}/{cid}/trees/by_gene/{hmm}.nwk'
+    cluster = 'clusters/{ani}/{cid}'
   output :
     table = 'clusters/{ani}/{cid}/data.tsv'
   params :
@@ -121,26 +105,24 @@ rule clusterdata :
       LOG.write( 'ANI        : {ani}\n'.format( ani=params.ani ) )
       LOG.write( 'cluster ID : {cid}\n'.format( cid=params.cid ) )
       
-      LOG.write( 'input trees :\n' )
-      for treefile in input.trees :
-        LOG.write( '    {f}\n'.format( f=treefile ) )
-      
+      treepaths = {}
+      for ani,cid,hmm,tree for RTM.filter( ani=params.ani,
+                                           cid=params.cid ).iter_rows() :
+        LOG.write( '  {hmm} -> {tree}\n'.format( hmm=hmm, tree=tree ) )
+        treepaths[hmm] = tree
+
       data = []
       
-      for treepath1, treepath2 in combinations( input.trees, 2 ) :
+      for hmm1, hmm2 in combinations( treepaths.keys(), 2 ) :
         
-        # if a tree is redundant, use the base tree
-        treefile1 = REDUNDANT_TREE_MAP[ treepath1 ]
-        treefile2 = REDUNDANT_TREE_MAP[ treefile2 ]
+        treefile1 = treepaths[hmm1]
+        treefile2 = treepaths[hmm2
         
         # if either treefile is an empty sentilel file, skip the calculations
         if os.stat( treefile1 ).st_size == 0 : continue
         if os.stat( treefile2 ).st_size == 0 : continue
         
-        hmm1_name = Path( treefile1 ).stem.rsplit( '.', 1 )[0]
-        hmm2_name = Path( treefile2 ).stem.rsplit( '.', 1 )[0]
-        
-        LOG.write( 'loading {g1} and {g2}...\n'.format( g1=hmm1_name, g2=hmm2_name ) )
+        LOG.write( 'loading {g1} and {g2}...\n'.format( g1=hmm1, g2=hmm2 ) )
         
         T1 = SuchTree( treefile1 )
         T2 = SuchTree( treefile2 )
@@ -170,10 +152,10 @@ rule clusterdata :
         
         # skip degenerate trees
         if len( unique( hmm1_distances ) ) / len( hmm1_distances ) < DEGEN_THRESHOLD :
-          LOG.write( '    {g1} is degenerate, skipping.\n'.format( g1=hmm1_name ) )
+          LOG.write( '    {g1} tree is degenerate, skipping.\n'.format( g1=hmm1 ) )
           continue
         if len( unique( hmm2_distances ) ) / len( hmm2_distances ) < DEGEN_THRESHOLD :
-          LOG.write( '    {g2} is degenerate, skipping.\n'.format( g2=hmm2_name ) )
+          LOG.write( '    {g2} tree is degenerate, skipping.\n'.format( g2=hmm2 ) )
           continue
         
         hmm1_skew = skew( hmm1_distances )
@@ -184,16 +166,20 @@ rule clusterdata :
          
         hmm1_stdev = stdev( hmm1_distances )
         hmm2_stdev = stdev( hmm2_distances )
-         
+        
         r,pr = pearsonr(   hmm1_distances, hmm2_distances )
         t,pt = kendalltau( hmm1_distances, hmm2_distances )
         
+        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) \
+                  len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
+        
         bp_compat = bipartition_compatibility_ratio( T1, T2, links )
         
-        data.append(  { 'hmm1'          : hmm1_name,
-                        'hmm2'          : hmm2_name,
+        data.append(  { 'hmm1'          : hmm1,
+                        'hmm2'          : hmm2,
                         'hmm1_leafs'    : T1.n_leafs,
                         'hmm2_leafs'    : T2.n_leafs,
+                        'jaccard'       : jaccard,
                         'links'         : len(links),
                         'hmm1_skew'     : hmm1_skew,
                         'hmm2_skew'     : hmm2_skew,

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -61,7 +61,7 @@ for line in open( 'cluster_data/redundancy.tsv' ) :
                            cid,
                            'trees',
                            'by_gene',
-                           Path(basefasta).stem + '.nwk' ) )
+                           Path(basefasta).stem + '.nwk' )
   for fasta in fastas :
     ani, cid, folder, candidatefasta = Path( fasta ).parts
     hmm = Path(fasta).stem
@@ -170,7 +170,8 @@ rule clusterdata :
         r,pr = pearsonr(   hmm1_distances, hmm2_distances )
         t,pt = kendalltau( hmm1_distances, hmm2_distances )
         
-        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) ) / len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
+        jaccard = len( set( T1.leafs.keys() ) & set( T2.leafs.keys() ) )
+                / len( set( T1.leafs.keys() ) | set( T2.leafs.keys() ) )
         
         bp_compat = bipartition_compatibility_ratio( T1, T2, links )
         

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -69,19 +69,11 @@ for line in open( 'cluster_data/redundancy.tsv' ) :
 
 RTM = polars.DataFrame( RTM )
 
-WC = glob_wildcards( os.path.join( 'clusters',
-                                   '{ani}',
-                                   '{cid}' ) )
-
 rule all :
   output :
-    expand( os.path.join( 'clusters',
-                          '{ani}',
-                          '{cid}',
-                          'data.tsv' ),
-                 zip,
-                 ani=WC.ani,
-                 cid=WC.cid )
+    [ os.path.join( 'clusters', ani, cid, 'data.tsv' )
+      for ani in os.listdir( 'clusters' )
+      for cid in os.listdir( os.path.join( 'clusters', ani ) ) ]
 
 rule clusterdata :
   group : 'phylogenomics'

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -69,23 +69,19 @@ for line in open( 'cluster_data/redundancy.tsv' ) :
 
 RTM = polars.DataFrame( RTM )
 
-def cluster_data( wildcards ) :
-  
-  WC = glob_wildcards( os.path.join( 'clusters',
-                                     '{ani}',
-                                     '{cid}' ) )
-  
-  return expand( os.path.join( 'clusters',
-                               '{ani}',
-                               '{cid}',
-                                'data.tsv' ),
-                 zip,
-                 ani=WC.ani,
-                 cid=WC.cid )
+WC = glob_wildcards( os.path.join( 'clusters',
+                                   '{ani}',
+                                   '{cid}' ) )
 
 rule all :
   output :
-    cluster_data
+    expand( os.path.join( 'clusters',
+                          '{ani}',
+                          '{cid}',
+                          'data.tsv' ),
+                 zip,
+                 ani=WC.ani,
+                 cid=WC.cid )
 
 rule clusterdata :
   group : 'phylogenomics'

--- a/workflow/Snakefile3
+++ b/workflow/Snakefile3
@@ -56,8 +56,9 @@ def cluster_trees( wildcards ) :
   WC = glob_wildcards( os.path.join( 'clusters',
                                      '{ani}',
                                      '{cid}',
-                                     'genes',
-                                     '{hmm}.fna' ) )
+                                     'trees',
+                                     'by_gene',
+                                     '{hmm}.nwk' ) )
   
   return expand( os.path.join( 'clusters',
                                '{ani}',
@@ -71,8 +72,8 @@ def cluster_trees( wildcards ) :
                  hmm=WC.hmm )
 
 rule all :
-  output :
-    'clusters/{ani}/{cid}/data.tsv'
+  input :
+    cluster_trees
 
 rule symlinks :
   group : 'phylogenomics'

--- a/workflow/utils/__init__.py
+++ b/workflow/utils/__init__.py
@@ -1,6 +1,6 @@
 import os
 from Bio.SeqIO import parse
-from itertools import chain, islice
+from itertools import chain, islice, product
 from collections import defaultdict
 
 # itertools.batched won't be available until 3.12.

--- a/workflow/utils/__init__.py
+++ b/workflow/utils/__init__.py
@@ -1,6 +1,7 @@
 import os
 from Bio.SeqIO import parse
 from itertools import chain, islice
+from collections import defaultdict
 
 # itertools.batched won't be available until 3.12.
 def batched( iterable, size=10 ) :

--- a/wrappers/fasttree/wrapper.py
+++ b/wrappers/fasttree/wrapper.py
@@ -1,7 +1,7 @@
-__author__ = "Nikos Tsardakas Renhuldt"
+__author__    = "Nikos Tsardakas Renhuldt"
 __copyright__ = "Copyright 2021, Nikos Tsardakas Renhuldt"
-__email__ = "nikos.tsardakas_renhuldt@tbiokem.lth.se"
-__license__ = "MIT"
+__email__     = "nikos.tsardakas_renhuldt@tbiokem.lth.se"
+__license__   = "MIT"
 
 
 from snakemake.shell import shell
@@ -27,5 +27,5 @@ else :
         ' -out {snakemake.output.tree}'
         ' -log {snakemake.log[0]}'
         ' {snakemake.input.alignment}'
-        ' LOG'
+        ' {LOG}'
     )

--- a/wrappers/fasttree/wrapper.py
+++ b/wrappers/fasttree/wrapper.py
@@ -7,7 +7,7 @@ __license__ = "MIT"
 from snakemake.shell import shell
 import os
 
-log = snakemake.log_fmt_shell( stdout=True, stderr=True )
+LOG = snakemake.log_fmt_shell( stdout=True, stderr=True )
 extra = snakemake.params.get( 'extra', '' )
 
 # if there are fewer than two records in the input file, write an
@@ -27,5 +27,5 @@ else :
         ' -out {snakemake.output.tree}'
         ' -log {snakemake.log[0]}'
         ' {snakemake.input.alignment}'
-        ' {log}'
+        ' LOG'
     )

--- a/wrappers/mafft/wrapper.py
+++ b/wrappers/mafft/wrapper.py
@@ -26,5 +26,8 @@ else :
     
     # Executed shell command
     shell(
-        'mafft {extra} {snakemake.input[0]} > {snakemake.output[0]}'
+        'mafft {extra} '
+        '{snakemake.input[0]} '
+        '> {snakemake.output[0]} '
+        '{log}'
     )

--- a/wrappers/trimal/wrapper.py
+++ b/wrappers/trimal/wrapper.py
@@ -10,6 +10,8 @@ import os
 log = snakemake.log_fmt_shell( stdout=True, stderr=True )
 extra = snakemake.params.get( 'extra', '' )
 
+empty_output_warning = 'WARNING: Output alignment has not been generated. It is empty.'
+
 # if there are fewer than two records in the input file, write an
 # empty output file and exit.
 if open( snakemake.input[0] ).read().count( '>' ) < 3 :
@@ -28,3 +30,9 @@ else :
         ' {extra}'
         ' {log}'
     )
+
+    if empty_output_warning in open( snakemake.log[0] ).read() :
+       with open( snakemake.log[0], 'w' ) as f :
+          f.write( '\n Snakemake wrapper : writing empty file anyway.' )
+       with open( snakemake.output[0], 'w' ) as f :
+          f.write( '' )


### PR DESCRIPTION
This branch updates the `cluster_data` to its own workflow, which now generates output filesnames from the redundancy table. The rule also uses the redundancy table to avoid the need to  build trees for alignments that exist in other clusters.